### PR TITLE
cpp template追加

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,5 +4,5 @@
 	"default-task-dirname-format": "{tasklabel}",
 	"default-test-dirname-format": "test",
 	"default-task-choice": "all",
-	"default-template": "ts"
+	"default-template": "cpp"
 }

--- a/cpp/.vscode/launch.json
+++ b/cpp/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "(LLDB) Debug",
+      "type": "lldb",
+      "request": "launch",
+      "program": "${fileDirname}/${fileBasenameNoExtension}",
+      "cwd": "${fileDirname}/",
+      "stdio": "${fileDirname}/test/sample-1.in",
+      "stopOnEntry": false,
+      "preLaunchTask": "clang++ build active file",
+    }
+  ]
+}

--- a/cpp/.vscode/tasks.json
+++ b/cpp/.vscode/tasks.json
@@ -1,0 +1,80 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "shell",
+      "label": "g++ build active file",
+      "command": "g++",
+      "args": [
+        "-std=gnu++17",
+        "-g",
+        "-Wall",
+        "${file}",
+        "-I",
+        "/Library/Developer/CommandLineTools/usr/include/ac-library",
+        "-o",
+        "${fileDirname}/${fileBasenameNoExtension}"
+      ],
+      "options": {
+        "cwd": "${fileDirname}"
+      },
+      "problemMatcher": [
+        "$gcc"
+      ],
+      "hide": true,
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    },
+    {
+      "type": "shell",
+      "label": "clang++ build active file",
+      "command": "clang++",
+      "args": [
+        "-std=c++17",
+        "-stdlib=libc++",
+        "-x",
+        "c++",
+        "-Wall",
+        "${file}",
+        "-I",
+        "/Library/Developer/CommandLineTools/usr/include/ac-library",
+        "-o",
+        "${fileDirname}/${fileBasenameNoExtension}",
+        "--debug"
+      ],
+      "hide": true,
+      "group": "build"
+    },
+    {
+      "label": "CheckTestCase",
+      "type": "shell",
+      "command": "oj test -c \"${fileDirname}/${fileBasenameNoExtension}\"",
+      "options": {
+        "cwd": "${fileDirname}"
+      },
+      "dependsOn": [
+        "g++ build active file"
+      ],
+      "presentation": {
+        "reveal": "always",
+        "focus": true,
+        "panel": "shared",
+      }
+    },
+    {
+      "label": "SubmitCode",
+      "type": "shell",
+      "command": "acc submit -s -- -y",
+      "options": {
+        "cwd": "${fileDirname}"
+      },
+      "presentation": {
+        "reveal": "always",
+        "focus": true,
+        "panel": "shared",
+      }
+    },
+  ]
+}

--- a/cpp/LICENSE.txt
+++ b/cpp/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 sakananonitsuke
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/cpp/Main.cpp
+++ b/cpp/Main.cpp
@@ -1,0 +1,11 @@
+#include <bits/stdc++.h>
+#include <atcoder/all>
+
+using namespace std;
+using namespace atcoder;
+
+int main()
+{
+  cout << "Hello" << endl;
+  cout << "World" << endl;
+}

--- a/cpp/template.json
+++ b/cpp/template.json
@@ -1,0 +1,15 @@
+{
+    "task": {
+        "program": [
+            "Main.cpp",
+            "package.json"
+        ],
+        "submit": "Main.cpp"
+    },
+    "contest": {
+        "static": [
+            ".vscode/tasks.json",
+            ".vscode/launch.json"
+        ]
+    }
+}


### PR DESCRIPTION
Intel MacOSで動作

以下にac-libraryを配置
`/Library/Developer/CommandLineTools/usr/include/`